### PR TITLE
feat: :sparkles: add contract version

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cw2::set_contract_version;
 // use cw2::set_contract_version;
 
 use crate::error::ContractError;
@@ -8,11 +9,9 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::{Config, State, Status, CONFIG, STATE};
 use crate::{exec, query};
 
-/*
 // version info for migration info
-const CONTRACT_NAME: &str = "crates.io:bidwasm";
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
-*/
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -21,6 +20,8 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     // If commission is passed as an argument, use it. Otherwise, use 0
     let commission = msg.commission.unwrap_or_default();
 


### PR DESCRIPTION
Adding the contract version on the storage for possible future migration.